### PR TITLE
fix(items): deduplicate diagnostic items

### DIFF
--- a/lua/neo-tree/sources/diagnostics/lib/items.lua
+++ b/lua/neo-tree/sources/diagnostics/lib/items.lua
@@ -97,6 +97,7 @@ M.get_diagnostics = function(state)
   root.search_pattern = state.search_pattern
   context.folders[root.path] = root
 
+  local encountered = {}
   local diag_items_by_buffer = {}
   for _, diag in ipairs(vim.diagnostic.get()) do
     local bufnr = diag.bufnr
@@ -105,7 +106,10 @@ M.get_diagnostics = function(state)
       if diag_items_by_buffer[bufnr] == nil then
         diag_items_by_buffer[bufnr] = {}
       end
-      table.insert(diag_items_by_buffer[bufnr], diag_item)
+      if not encountered[diag_item.id] then
+        table.insert(diag_items_by_buffer[bufnr], diag_item)
+      end
+      encountered[diag_item.id] = true
     end
   end
 


### PR DESCRIPTION
Hello!

Thank you for this plugin. Neo-tree is great, and providers like this could make it the best tool for the classic use case of "efficiently scanning many positions scattered across many files" (it'd also need a way to easily jump to the previous/next position, from the file split, I guess).

Anyway, the Elixir LSP server was sending the same warning (from the tool Dialyzer) 3 times, and it made NuiTree fail (https://github.com/MunifTanjim/nui.nvim/blob/main/lua/nui/tree/init.lua#L53). I thought I'd give it a try before filing an issue. I'm not used to Lua so it may not be _the Lua way_ but it did fix my issue :)

Pierre