### PR TITLE
feat: add explicit directory renderer config

### DIFF
--- a/lua/neo-tree/sources/diagnostics/defaults.lua
+++ b/lua/neo-tree/sources/diagnostics/defaults.lua
@@ -26,6 +26,11 @@ local config = {
                        -- Set to `false` for no maximum
   },
   renderers = {
+    directory = {
+      { "indent" },
+      { "icon" },
+      { "name" },
+    },
     file = {
       { "indent" },
       { "icon" },


### PR DESCRIPTION
In a recent commit, the default renderer for the directory type adds columns for things like Size, Type, Last Modified. This does not fit with the diagnostics so I thought it was best to add an explicit renderer for directories so that it does not inherit it from the glocal directory renderer.

See https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1107 for details.
