### PR TITLE
feat(init.lua): Added a display name

### DIFF
--- a/lua/neo-tree/sources/diagnostics/init.lua
+++ b/lua/neo-tree/sources/diagnostics/init.lua
@@ -11,7 +11,10 @@ local diag_highlights = require("neo-tree.sources.diagnostics.highlights")
 local defaults = require("neo-tree.sources.diagnostics.defaults")
 local log = require("neo-tree.log")
 
-local M = { name = "diagnostics" }
+local M = {
+    name = "diagnostics",
+    display_name = " Diagnostics",
+}
 
 local wrap = function(func)
   return utils.wrap(func, M.name)


### PR DESCRIPTION
Setting the display name allows to set an icon in the source selectors

![image](https://github.com/mrbjarksen/neo-tree-diagnostics.nvim/assets/61845593/2b25f26f-7873-4f83-a8da-a60409d3691e)

previously it just said "diagnostics" in lowercase.

Small fix but I thought it'd be better to just commit upstream rather than keep a patch for myself :)